### PR TITLE
Include run number in update branch name

### DIFF
--- a/.github/workflows/sync-countdown-with-gcal.yml
+++ b/.github/workflows/sync-countdown-with-gcal.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
-        ref: calendar-sync-update
+        ref: calendar-sync-update-${{ github.run_number }}-${{ github.run_attempt }}
         fetch-depth: 0
         token: ${{ secrets.GH_TOKEN }}
 
@@ -115,7 +115,7 @@ jobs:
         git config user.email "FabianVolkers@users.noreply.github.com"
         git add $TARGET_MARKDOWN_FILES
         git commit -m "Update target_date in $TARGET_MARKDOWN_FILES" || exit 0
-        git push origin calendar-sync-update
+        git push origin calendar-sync-update-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT || exit 0
 
     - name: Create pull request
       if: ${{ steps.check_target_date.outputs.target_date_updated == '1' }}
@@ -123,7 +123,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
-        response=$(curl -s -w "%{http_code}" -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token $GH_TOKEN" "https://api.github.com/repos/${{ github.repository }}/pulls" -d '{"title":"Update target_date in index.markdown","head":"calendar-sync-update","base":"main","maintainer_can_modify": true}')
+        response=$(curl -s -w "%{http_code}" -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token $GH_TOKEN" "https://api.github.com/repos/${{ github.repository }}/pulls" -d '{"title":"Update target_date in index.markdown","head":"calendar-sync-update-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT","base":"main","maintainer_can_modify": true}')
         status_code=$(echo "$response" | tail -n1)
         pr_data=$(echo "$response" | head -n-1)
         if [ $status_code -ne 201 ]; then
@@ -151,5 +151,5 @@ jobs:
     - name: Delete calendar-sync-update branch
       if: ${{ steps.merge_pr.outputs.merge_status == 200 }}
       run: |
-        git push origin --delete calendar-sync-update
+        git push origin --delete calendar-sync-update-$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT
 


### PR DESCRIPTION
This avoids errors in updating whenever a previews PR could not be
automatically closed